### PR TITLE
Fixed minor bugs with navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 
 </head>
 
-<body data-spy="scroll" data-target=".navbar" data-offset="60">
+<body data-spy="scroll" data-target=".navbar" data-offset="70">
 
 <!-- Page Header -->
 <div class="page-header jumbotron" id="page-header">
@@ -52,7 +52,7 @@
 </div>
 
 <!-- Navigation -->
-<div class="navbar-container">
+<div class="navbar-container" id="navbar-container">
 <nav class="navbar navbar-default" id="navbar">
     <div class="container-fluid">
         <div class="navbar-header">

--- a/res/js/index.js
+++ b/res/js/index.js
@@ -23,7 +23,8 @@ $(function () {
             // Using jQuery's animate() method to add smooth page scroll
             // The optional number (800) specifies the number of milliseconds it takes to scroll to the specified area
             $('html, body').animate({
-                scrollTop: $(hash).offset().top - 50
+                // Subtract the size of navbar container (if not affixed will compensate for increased page height, if affixed compensates for navbar height)
+                scrollTop: $(hash).offset().top - $('#navbar-container').outerHeight()
             }, 800, function() {
 
                 // Add hash (#) to URL when done scrolling (default click behavior)


### PR DESCRIPTION
- Increased scrollspy offset (sections weren't getting highlighted correctly)
- Smooth scroll now goes to the top of the section regardless of whether the navbar is affixed. It calculates the height of the navbar container and subtracts that from section offset